### PR TITLE
Adicionando is_scoring ao post do Importar Repositório do Github.

### DIFF
--- a/src/components/GitHub/GitHubProjects.vue
+++ b/src/components/GitHub/GitHubProjects.vue
@@ -117,6 +117,7 @@ function doRequisitions(repos, length) {
       HTTP.post(`users/${userId}/projects`, {
         name: repo,
         is_project_from_github: true,
+        is_scoring: false,
       }, { headers })
         .then((response) => {
           count++;


### PR DESCRIPTION
Signed-off-by: Pedro Kelvin <pedrokelvin2006@gmail.com>

## Mudanças Propostas
O atributo is_scoring é necessário para importar um repositório do Github e não tinha no post do Front. Então foi adicionado esse atributo. 

## Tipo de Mudança

Que tipo de mudanças este Pull Request introduz ao Falko?
_Marque um `x` ao que se aplicar_

- [x] Conserto de Bug
- [ ] Nova Feature

## Checklist

_Marque um `x` ao que se aplicar. Se você não tiver certeza sobre algum dos tópicos, não hesite em perguntar. Estamos aqui para ajudar!_

- [x] O nome do pull request deve ser auto-explicativo e deve estar em português.
- [x] Os commits seguem a [política de commits do repositório](https://github.com/fga-gpp-mds/Falko-2017.2-BackEnd/wiki/Plano-de-Gerenciamento-de-Configura%C3%A7%C3%A3o-de-Software#41---pol%C3%ADtica-de-commits).
- [x] Não há erros de linter.
- [x] A build está passando (testes, code climate e codacy).
- [x] O pull request está linkado à uma issue existente.

## Screenshots

## Outros Comentários
