### PR TITLE
Mudando o botão de sprint

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -33,7 +33,7 @@
                 <span  v-if="this.$route.path == '/releases/'+this.$route.params.id ||
                 this.$route.path == '/releases/'+this.$route.params.id+'/sprints' ||
                 this.$route.path == '/sprints/'+this.$route.params.id"
-                class="sidebar-icon"><i class=" fa fa-repeat"></i></span>
+                class="sidebar-icon"><i class="fa fa-angle-double-down"></i></span>
                 <span class="sidebar-title"></span>
               </a>
             </router-link>


### PR DESCRIPTION
Signed-off-by: Leonardo Dos Santos Silva Barreiros <leossb36@gmail.com>

## Mudanças Propostas

Mudando o botão de sprint

## Tipo de Mudança

Que tipo de mudanças este Pull Request introduz ao Falko?
_Marque um `x` ao que se aplicar_

- [x] Conserto de Bug
- [ ] Nova Feature

## Checklist

_Marque um `x` ao que se aplicar. Se você não tiver certeza sobre algum dos tópicos, não hesite em perguntar. Estamos aqui para ajudar!_

- [x] O nome do pull request deve ser auto-explicativo e deve estar em português.
- [x] Os commits seguem a [política de commits do repositório](https://github.com/fga-gpp-mds/Falko-2017.2-BackEnd/wiki/Plano-de-Gerenciamento-de-Configura%C3%A7%C3%A3o-de-Software#41---pol%C3%ADtica-de-commits).
- [x] Não há erros de linter.
- [x] A build está passando (testes, code climate e codacy).
- [x] O pull request está linkado à uma issue existente.

## Screenshots
Se  possível, incluir screenshots das modificações  feitas.

## Outros Comentários

Por conta da dificuldade de encontrar um botão adequado a sprint, selecionei um "fa fa-angle-double-down" com base pesquisas para uma melhor representação do mesmo. A imagem a seguir é a referencia de onde foi tirado a ideia. Apesar de ser apenas um layout do criador da imagem para explicar o processo de sprint, a ideia foi baseada na mesma pelo motivo que, em pesquisas na internet sprint era representada por setas com movimentos de loop, entretanto como explicado anteriormente não foi possível encontrar uma representação fiel, então optei por utilizar apenas da referencia das setas do layout como uma representação de sprint, sendo duas setas apontando para baixo. 

![slide3](https://user-images.githubusercontent.com/26796127/32950383-44d7be1a-cb8d-11e7-9263-0226c21410fb.JPG) 
----
### Antes
![captura de tela de 2017-11-17 16-03-04](https://user-images.githubusercontent.com/26796127/32961742-da13ee36-cbb0-11e7-8f06-2db5515ffce2.png)

### Depois
![captura de tela de 2017-11-17 16-02-42](https://user-images.githubusercontent.com/26796127/32961738-d6b3a696-cbb0-11e7-8472-c44fd15664f4.png)

