### PR TITLE
Tirando icone de sprint e releases quando desnecessários

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -22,7 +22,8 @@
           <li align="center">
             <router-link to="/projects">
               <a  title="Projects">
-                <span class="sidebar-icon"><i class=" fa fa-file"></i></span>
+                <span v-if="this.$route.path != '/projects'"
+                 class="sidebar-icon"><i class=" fa fa-file"></i></span>
                 <span class="sidebar-title"></span>
               </a>
             </router-link>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -31,7 +31,6 @@
             <router-link v-bind:to="'/releases/'+this.$route.params.id+'/sprints'">
               <a  title="Sprints" id="popover">
                 <span  v-if="this.$route.path == '/releases/'+this.$route.params.id ||
-                this.$route.path == '/releases/'+this.$route.params.id+'/sprints' ||
                 this.$route.path == '/sprints/'+this.$route.params.id"
                 class="sidebar-icon"><i class=" fa fa-repeat"></i></span>
                 <span class="sidebar-title"></span>
@@ -43,8 +42,7 @@
               <a  title="Releases" >
                 <span v-if="this.$route.path == '/projects/'+this.$route.params.id ||
                 this.$route.path == '/releases/'+this.$route.params.id+'/sprints' ||
-                this.$route.path == '/releases/'+this.$route.params.id ||
-                this.$route.path == '/projects/'+this.$route.params.id+'/releases'"
+                this.$route.path == '/releases/'+this.$route.params.id"
                 class="sidebar-icon"><i class=" fa fa-cube"></i></span>
                 <span class="sidebar-title"></span>
               </a>


### PR DESCRIPTION
…ndex

## Mudanças Propostas

Remover da sidebar os icones de Sprint e Releases quando usuários estão em suas respectivas index.

## Tipo de Mudança

Que tipo de mudanças este Pull Request introduz ao Falko?
_Marque um `x` ao que se aplicar_

- [ ] Conserto de Bug
- [x] Nova Feature

## Checklist

_Marque um `x` ao que se aplicar. Se você não tiver certeza sobre algum dos tópicos, não hesite em perguntar. Estamos aqui para ajudar!_

- [x] O nome do pull request deve ser auto-explicativo e deve estar em português.
- [x] Os commits seguem a [política de commits do repositório](https://github.com/fga-gpp-mds/Falko-2017.2-BackEnd/wiki/Plano-de-Gerenciamento-de-Configura%C3%A7%C3%A3o-de-Software#41---pol%C3%ADtica-de-commits).
- [x] Não há erros de linter.
- [x] A build está passando (testes, code climate e codacy).
- [x] O pull request está linkado à uma issue existente.

## Screenshots
![index_release](https://user-images.githubusercontent.com/27258892/33074665-2cd38230-ceae-11e7-9e77-67c32ac8ee8e.png)
![index_sprint](https://user-images.githubusercontent.com/27258892/33074678-2fa032e2-ceae-11e7-83cd-322a9ea493b0.png)


## Outros Comentários
Se for uma mudança relativamente grande/complexa e você tiver algum comentário/pergunta a fazer, explicação de sua escolha da sua solução ou qualquer coisa que ache relevante, não hesite em compartilhar.
