### PR TITLE
Fixed broken link to CONTRIBUTING.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The full version of our documentation can be found on our [Wiki](https://github.
 
 ## Contributing
 
-Thanks for join us on Falko! Make sure to read the [Contribution Guide](https://github.com/falko-org/Falko-2017.2-FrontEnd/blob/devel/CONTRIBUTING.md) before opening a pull request.
+Thanks for join us on Falko! Make sure to read the [Contribution Guide](https://github.com/falko-org/Falko/blob/devel/.github/CONTRIBUTING.md) before opening a pull request.
 
 You can find information about the installation [here](https://github.com/falko-org/Falko-2017.2-BackEnd/wiki/Como-Usar-o-Docker).
 


### PR DESCRIPTION
## Proposed Changes

The `Contribution Guide` link in README.md currently links to https://github.com/falko-org/Falko/blob/devel/CONTRIBUTING.md which leads to a 404 on GitHub. I changed the link to https://github.com/falko-org/Falko/blob/devel/.github/CONTRIBUTING.md which links to the current CONTRIBUTING.md file in the current devel branch.

## Type of Changes

What type of change this Pull Request brings to Falko?
_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New Feature

## Checklist

_Put an `x` in the boxes that apply. If you're confused about any of the following topics, ask us. We're here to help you!_

- [x] This Pull Request has a significant name.
- [x] The build is okay (tests, code climate).
- [x] This Pull Request mentions a related issue.

