### PR TITLE
Renaming footer copyright

### DIFF
--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -53,9 +53,9 @@
       </div>
     </div>
     <div class="card-footer" id="footer">
-      <a>
-        Copyright (c) 2017 Falko - UnB-FGA (GPP/MDS) Grupo 8 Segundo Semestre de 2017
-      </a>
+      <a><h5>Copyright (c) 2017 Falko</h5></a>
+      <div>All Rights Reserved.</div>
+      <a>This product is protected by copyright and distributed under licenses restricting copying, distribution, and decompilation.</a>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Proposed Changes

Changing the copyright phrase

## Type of Changes

- [x] Improvement

## Screenshots
the new footer
![captura de tela de 2019-03-07 17-40-45](https://user-images.githubusercontent.com/26796127/53987718-90ffcf00-4100-11e9-8c42-7fd63d53ba54.png)

