### PR TITLE
Adding error message in issue graphics

### DIFF
--- a/src/components/Issues/IssuesGraphic.vue
+++ b/src/components/Issues/IssuesGraphic.vue
@@ -68,6 +68,13 @@
         </div>
       </div>
   </div>
+  <div v-else class="empty-issues">
+    <h1>There are no issues in this project</h1>
+    <div class="error-icons">
+      <i class="fa fa-times-circle-o empty-issues-icon" aria-hidden="true"></i>
+      <i class="fa fa-list-alt issues-icon" aria-hidden="true"></i>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -421,6 +428,31 @@ h6 {
 
 .arrow-image {
   width: 0.95em;
+}
+
+.empty-issues {
+  padding: 8%;
+}
+
+.error-icons {
+  position: relative;
+  display: inline-flex;
+}
+
+.issues-icon {
+  z-index: 1;
+  padding-top: 20px;
+  font-size: 150px;
+  color: #688E9B;
+}
+
+.empty-issues-icon {
+  z-index: 2;
+  position: absolute;
+  bottom: -20px;
+  right: -30px;
+  font-size: 100px;
+  color: #3E5361;
 }
 
 </style>


### PR DESCRIPTION
## Proposed Changes
Solution of issue "Mostrar mensagem de erro caso não seja possível visualizar gráfico de issues" #267.

Adding error message in place of the issues graph if there are no issues in the project.

## Type of Changes

What type of change this Pull Request brings to Falko?
_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New Feature

## Checklist

_Put an `x` in the boxes that apply. If you're confused about any of the following topics, ask us. We're here to help you!_

- [x] This Pull Request has a significant name.
- [x] The build is okay (tests, code climate).
- [x] This Pull Request mentions a related issue.

## Screenshots
![photo_2019-04-18_17-25-50](https://user-images.githubusercontent.com/18334508/56430724-9e7eac00-629d-11e9-8882-56423564aab7.jpg)

## Further Comments
In case the project is created in Falko, like the two already created ("Owla" and "Falko"), when going to the main page of the project, where the issues graph is located, the backend is returning a 500 error to the front-end, so it looks like it's trying to get the issues data from that project in GitHub's api, but that does not exist, thus returning a 404 error that is not handled in the backend, a 500 error occurs.

![photo_2019-04-19_12-42-00](https://user-images.githubusercontent.com/18334508/56431584-98d69580-62a0-11e9-9813-1bf7e9e571cd.jpg)

Back-end:
`falko-api | Completed 500 Internal Server Error in 637ms (ActiveRecord: 5.4ms)`
`falko-api | Octokit::NotFound (GET https://api.github.com/issues?per_page=100&state=all: 404 - Not Found // See: https://developer.github.com/v3/issues/#list-issues):`